### PR TITLE
fix: always reset startX and startY values

### DIFF
--- a/hooks/useGestureHandlerValues.ts
+++ b/hooks/useGestureHandlerValues.ts
@@ -51,12 +51,7 @@ const useGestureHandlerValues = ({ active }) => {
         const distanceHipo = getHipotenus(offsetX, offsetY);
 
         if (distanceHipo > 100 || velocityHipo > 500) {
-          active.value = withSpring(0, SPRING_CONFIGURATION, (finished) => {
-            if (finished) {
-              startX.value = 0;
-              startY.value = 0;
-            }
-          });
+          active.value = withSpring(0, SPRING_CONFIGURATION);
         }
       }
     })
@@ -64,6 +59,8 @@ const useGestureHandlerValues = ({ active }) => {
       if (active) {
         isPressed.value = false;
       }
+      startX.value = 0
+      startY.value = 0
     });
 
   return {


### PR DESCRIPTION
Previously the start values would only be reset on a successful swipe to dismiss gesture. This would lead to a small bug where - when the swipe to dismiss gesture was canceled and retried - the screen would jerk to the previous values instead of start off from a fresh starting position. This fixes that.